### PR TITLE
#41 Add caching for Bundler

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -54,8 +54,8 @@ workflows:
       Building Application and running Unit-Tests.
     before_run:
     - _clone_repo
+    - Install-Bundler
     steps:
-    - install-bundler: {}
     - fastlane:
         timeout: 300
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -17,6 +17,38 @@ workflows:
     - git-clone:
         asset_urls:
           icon.svg: https://bitrise-steplib-collection.s3.amazonaws.com/steps/git-clone/assets/icon.svg
+  bundler-installation:
+    description: |-       
+      Private workflow for installing (`install-bundler` step) and saving to cache. 
+    steps:
+    - install-bundler: {}
+    - script:
+        title: Set Ruby version to an env var
+        inputs:
+        - content: |-
+            ruby_version=$(head -n 1 .ruby-version)
+            envman add --key RUBY_VERSION --value "$ruby_version"
+    - save-cache:
+        title: Save Bundler cache
+        inputs:
+        - key: bundler-cache-{{ .Arch }}-{{ checksum "Gemfile.lock" }}
+        - paths: |-
+            ~/.rbenv/versions/$RUBY_VERSION
+            ~/.asdf/installs/ruby/$RUBY_VERSION
+  Install-Bundler:
+    description: |- 
+      Restoring Bundler from key-based cache (key is `bundler-cache-{{ .Arch }}-{{ checksum "Gemfile.lock" }}`).
+      If cache was not restored - then installing (`install-bundler` step) and saving to cache. 
+    steps:
+    - restore-cache:
+        title: Restore Bundler cache
+        inputs:
+        - key: bundler-cache-{{ .Arch }}-{{ checksum "Gemfile.lock" }}
+    - bitrise-run:
+        title: Bundler Installation and saving to cache
+        run_if: '{{not enveq "BITRISE_CACHE_HIT" "exact"}}'
+        inputs:
+        - workflow_id: bundler-installation
   Run-Unit-Tests:
     description: |- 
       Building Application and running Unit-Tests.

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -46,7 +46,7 @@ workflows:
         - key: bundler-cache-{{ .Arch }}-{{ checksum "Gemfile.lock" }}
     - bitrise-run:
         title: Bundler Installation and saving to cache
-        run_if: '{{not enveq "BITRISE_CACHE_HIT" "exact"}}'
+        run_if: '{{not (enveq "BITRISE_CACHE_HIT" "exact")}}'
         inputs:
         - workflow_id: bundler-installation
   Run-Unit-Tests:


### PR DESCRIPTION
## Issue link
#41 

## PR description
Use Bitrise key-based caching for storing Bundler and reuse (instead of actual installation) in case if `Gemfile.lock` is not changed.
This approach will improve Bitrise build timing by 10% (**~2m50s** instead of **~3m10s**) and save **2 credits** per each build